### PR TITLE
fix(setup): 修复 macOS launchd bootstrap 与 Homebrew PATH

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -171,14 +171,22 @@ env_file="$conf_dir/$KEY.conf"
 #   - systemd: 直接当 EnvironmentFile=...
 #   - launchd: 生成的 plist 通过 `set -a; . FILE; set +a` 内联加载（无 EnvironmentFile 等价物）
 # 都需要 PATH——systemd user service / launchd LaunchAgent 默认 PATH 都很瘦，
-# 把 worker CLI 所在目录拼进去。
+# 把 worker CLI 所在目录拼进去；macOS Homebrew（Apple Silicon）默认在 /opt/homebrew/bin。
 worker_path="$(dirname "$(command -v "$WORKER_BIN")")"
-cat > "$env_file" <<EOF
+daemon_path="$worker_path:$HOME/.local/bin"
+if [ "$OS" = "Darwin" ] && [ -d /opt/homebrew/bin ]; then
+    daemon_path="/opt/homebrew/bin:$daemon_path"
+fi
+if [ -f "$env_file" ]; then
+    echo "  ⚠️  已存在，跳过（手动检查 PATH 是否需要更新）"
+else
+    cat > "$env_file" <<EOF
 PROJECT_ROOT=$HOST
 CODING_AGENT_CONFIG=$config
-PATH=$worker_path:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin
+PATH=$daemon_path:/usr/local/bin:/usr/bin:/bin
 EOF
-echo "  ✓ $env_file"
+    echo "  ✓ $env_file"
+fi
 
 # ── 4. 安装调度器 unit（按 OS 分支）──
 echo
@@ -288,7 +296,7 @@ enable_launchd() {
     local label="dev.luosky.coding-agent-work-loop.$KEY"
     local plist="$HOME/Library/LaunchAgents/$label.plist"
     local log_dir="$HOME/Library/Logs/coding-agent-work-loop"
-    read -rp "现在 bootstrap & start $label？[y/N] " yn
+    read -rp "现在 bootstrap & start ${label}？[y/N] " yn
     case "$yn" in
         y|Y|yes)
             # 已加载的话先 bootout 再 bootstrap，达到幂等 reload


### PR DESCRIPTION
## Summary

针对 PR #17（#8）在 macOS + Cursor 社区验收中发现的三个问题，提交最小修复：

1. **step 7 阻断性 bug**：`read -rp "... $label? ..."` 在 `set -u` 下被 bash 解析为未定义变量 `label?`，导致 bootstrap 无法完成 → 改为 `${label}?`
2. **launchd poll 找不到 flock**：Apple Silicon 上 `brew install flock` 位于 `/opt/homebrew/bin`，setup 生成的 `.conf` PATH 未包含该目录，launchd 子进程报 `flock: command not found` → Darwin 且目录存在时 prepend `/opt/homebrew/bin`
3. **重跑 setup 覆盖 conf**：step 3 改为 conf 已存在则跳过，避免抹掉用户手动修正的 PATH

## 背景

- 问题来源：upstream PR #17 社区验收 — https://github.com/luosky/coding-agent-work-loop/pull/17#issuecomment-4506922036
- **目标分支**：`feature/issue-8`（PR #17），合并本 PR 后 macOS launchd 路径可开箱即用

## 社区验收（macOS + Cursor）

**环境**：macOS 15.7.4 (Sequoia)，Apple Silicon，Cursor skill 已索引 `coding-agent-work-loop`  
**分支**：`fix/macos-launchd-setup-issues` @ `e5c56d8`  
**host repo**：`luohui8891/coding-agent-acceptance-test`

| 项 | PR #17（修复前） | 本 PR（修复后） |
|----|------------------|-----------------|
| setup step 7 | ❌ crash | ✅ `bootstrapped & kicked` |
| conf PATH 含 Homebrew | ❌ 需手动改 | ✅ 自动含 `/opt/homebrew/bin` |
| launchd poll（无手改 PATH） | ❌ flock not found | ✅ ≤60s `poll start` → `poll done` |
| 重跑 setup 覆盖 conf | ❌ | ✅ 「已存在，跳过」 |
| Cursor skill 发现 | — | ✅ UI 可见 |
| 卸载 cleanup | ✅ | ✅ |

**刻意未测**：Linux systemd 回归、`pending/agent` → tmux worker 全链路

## Test plan

- [x] `bash -n setup.sh`
- [x] macOS：`printf 'y\n' | bash setup.sh <host>` step 7 不再 crash
- [x] macOS：fresh install 后 launchd poll 60s 内出现 `===== poll start =====`（无需手动改 conf PATH）
- [x] macOS：重跑 setup，已有 `.conf` → 跳过不覆盖
- [x] macOS：Cursor Reload 后 Agent 可发现 `coding-agent-work-loop` skill
- [ ] Linux：PATH 逻辑不变（无 `/opt/homebrew/bin` 目录时不注入）— 未在本机验证，逻辑上仅 Darwin + 目录存在时注入