### PR TITLE
feat(drivers): 内置 Cursor Agent CLI driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ AI sees it's a discussion question, replies without touching code, keeps label `
 | [docs/persistence.md](docs/persistence.md) | Where design proposals / discussions / code / Claude conversations / tmux history live, how to look them up later, how to resume from a break point |
 | [docs/security.md](docs/security.md) | **Public-repo users must read.** Anonymous comments can contain prompt injection; how the defenses work |
 | [docs/operations.md](docs/operations.md) | Full config, prompt templates, multi-project, upgrades, macOS launchd, webhook trigger, swapping AI worker, troubleshooting |
-| [docs/drivers.md](docs/drivers.md) | Worker agent drivers — built-in `claude` / `opencode` / `codex`, plus how to add your own |
+| [docs/drivers.md](docs/drivers.md) | Worker agent drivers — built-in `claude` / `opencode` / `codex` / `cursor`, plus how to add your own |
 
 ## Note
 
-This is an **Agent Skill** — a feature package loaded by AI coding tools like Claude Code. But you don't need Claude Code to run it: the background scripts are plain shell + `gh` CLI, scheduled by cron / systemd / launchd. Worker CLI is selected via `WORKER_AGENT=<name>`; built-in `claude` / `opencode` / `codex` drivers ship; add your own — see [docs/drivers.md](docs/drivers.md).
+This is an **Agent Skill** — a feature package loaded by AI coding tools like Claude Code. But you don't need Claude Code to run it: the background scripts are plain shell + `gh` CLI, scheduled by cron / systemd / launchd. Worker CLI is selected via `WORKER_AGENT=<name>`; built-in `claude` / `opencode` / `codex` / `cursor` drivers ship; add your own — see [docs/drivers.md](docs/drivers.md).
 
 ## License
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -135,11 +135,11 @@ AI 看是讨论性问题，只回评论不动代码，标签保持 `pending/huma
 | [docs/persistence.md](docs/persistence.zh.md) | 设计方案 / 讨论 / 代码 / Claude 对话 / tmux 历史 都存哪、怎么事后查阅、怎么从断点续上 |
 | [docs/security.md](docs/security.zh.md) | **公开仓库务必读**。匿名评论可能塞 prompt injection（用提示词劫持 AI），怎么防 |
 | [docs/operations.md](docs/operations.zh.md) | 配置全字段、prompt 模板、多项目共存、升级、macOS launchd、即时触发 webhook、换其他 AI 工具、故障排查 |
-| [docs/drivers.md](docs/drivers.zh.md) | Worker agent driver —— 内置 `claude` / `opencode` / `codex`、加自家 driver 教程 |
+| [docs/drivers.md](docs/drivers.zh.md) | Worker agent driver —— 内置 `claude` / `opencode` / `codex` / `cursor`、加自家 driver 教程 |
 
 ## 备注
 
-本项目是个 **Agent Skill**——给 Claude Code 这类 AI 编程工具加载的功能包。但你不用 Claude Code 也能跑：后台脚本是纯 shell + `gh` 命令，cron / systemd / launchd 都能调度。Worker 选哪个 agent CLI 由 `WORKER_AGENT=<name>` 控制；内置 `claude` / `opencode` / `codex` 三个 driver，加自家 driver 见 [docs/drivers.zh.md](docs/drivers.zh.md)。
+本项目是个 **Agent Skill**——给 Claude Code 这类 AI 编程工具加载的功能包。但你不用 Claude Code 也能跑：后台脚本是纯 shell + `gh` 命令，cron / systemd / launchd 都能调度。Worker 选哪个 agent CLI 由 `WORKER_AGENT=<name>` 控制；内置 `claude` / `opencode` / `codex` / `cursor` 四个 driver，加自家 driver 见 [docs/drivers.zh.md](docs/drivers.zh.md)。
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,7 +9,7 @@ description: GitHub label-driven workflow that lets a local AI handle issues / P
 
 Turn GitHub issue / PR comments into the input and output of your local AI. A systemd timer + a few shell scripts + two GitHub labels let you talk to the AI directly through the GitHub web UI (or the iOS gh app).
 
-> This skill is agent-agnostic by design. Worker CLI is selected by `WORKER_AGENT=<name>` in `coding-agent.config`; the daemon / dispatch scripts go through a thin **driver layer** that plugs in different agent CLIs. Built-in drivers: `claude` (default, Claude Code), `opencode` (sst/opencode), `codex` (OpenAI Codex CLI). Add your own via `scripts/drivers/<name>.sh` — see [docs/drivers.md](docs/drivers.md).
+> This skill is agent-agnostic by design. Worker CLI is selected by `WORKER_AGENT=<name>` in `coding-agent.config`; the daemon / dispatch scripts go through a thin **driver layer** that plugs in different agent CLIs. Built-in drivers: `claude` (default, Claude Code), `opencode` (sst/opencode), `codex` (OpenAI Codex CLI), `cursor` (Cursor Agent CLI). Add your own via `scripts/drivers/<name>.sh` — see [docs/drivers.md](docs/drivers.md).
 
 ## When to invoke
 
@@ -26,7 +26,7 @@ The user calls this skill from the host agent runtime via `/coding-agent-work-lo
 The user gives you a host project path (e.g. `~/github/myproject`). Steps:
 
 1. Verify the path exists and is a git repo (has `.git`)
-2. Check deps: `git`, `gh` (must be logged in via `gh auth login`), `tmux`, `jq`, `flock`, `systemctl`, plus the worker CLI selected by `WORKER_AGENT` (default `claude`; other built-ins: `opencode`, `codex`). Each must resolve via `command -v`.
+2. Check deps: `git`, `gh` (must be logged in via `gh auth login`), `tmux`, `jq`, `flock`, `systemctl`, plus the worker CLI selected by `WORKER_AGENT` (default `claude`; other built-ins: `opencode`, `codex`, `cursor`). Each must resolve via `command -v`.
 3. Run:
    ```bash
    bash "${CLAUDE_PLUGIN_ROOT:-$HOME/.agents/skills/coding-agent-work-loop}/setup.sh" <host-project-path>

--- a/SKILL.zh.md
+++ b/SKILL.zh.md
@@ -9,7 +9,7 @@ description: 用 GitHub label 驱动本机 agent 处理 issue/PR，daemon 自动
 
 把 GitHub issue / PR 评论变成你本机 agent 的输入输出。一个 systemd timer + 几个 shell 脚本 + 两个 GitHub label，让你通过 GitHub 网页（或 iOS gh app）直接跟 agent 沟通。
 
-> 本 skill 设计上 agent-agnostic。Worker CLI 由 `coding-agent.config` 里的 `WORKER_AGENT=<name>` 选；daemon / dispatch 通过一层薄的 **driver 抽象**对接各家 agent CLI。内置 driver：`claude`（默认，Claude Code）、`opencode`（sst/opencode）、`codex`（OpenAI Codex CLI）。加自家 driver 见 [docs/drivers.zh.md](docs/drivers.zh.md)。
+> 本 skill 设计上 agent-agnostic。Worker CLI 由 `coding-agent.config` 里的 `WORKER_AGENT=<name>` 选；daemon / dispatch 通过一层薄的 **driver 抽象**对接各家 agent CLI。内置 driver：`claude`（默认，Claude Code）、`opencode`（sst/opencode）、`codex`（OpenAI Codex CLI）、`cursor`（Cursor Agent CLI）。加自家 driver 见 [docs/drivers.zh.md](docs/drivers.zh.md)。
 
 ## 触发方式
 
@@ -26,7 +26,7 @@ description: 用 GitHub label 驱动本机 agent 处理 issue/PR，daemon 自动
 用户给你一个 host project 路径（如 `~/github/myproject`）。你的步骤：
 
 1. 验证路径存在且是 git 仓库（`.git` 在）
-2. 检查依赖：`git`、`gh`（已 `gh auth login`）、`tmux`、`jq`、`flock`、`systemctl`，以及 `WORKER_AGENT` 选定的 worker CLI（默认 `claude`；其他内置：`opencode`、`codex`）都能 `command -v` 到
+2. 检查依赖：`git`、`gh`（已 `gh auth login`）、`tmux`、`jq`、`flock`、`systemctl`，以及 `WORKER_AGENT` 选定的 worker CLI（默认 `claude`；其他内置：`opencode`、`codex`、`cursor`）都能 `command -v` 到
 3. 跑：
    ```bash
    bash "${CLAUDE_PLUGIN_ROOT:-$HOME/.agents/skills/coding-agent-work-loop}/setup.sh" <host-project-path>

--- a/coding-agent.config.example
+++ b/coding-agent.config.example
@@ -139,6 +139,7 @@ WORKTREE_GIT_USER_EMAIL=""
 #   claude    — Claude Code           (default; behavior identical to pre-driver era)
 #   opencode  — OpenCode (sst/opencode)
 #   codex     — Codex CLI (OpenAI)
+#   cursor    — Cursor Agent CLI (`agent`; headless with -p --trust --force)
 # Custom: drop scripts/drivers/<name>.sh into the skill, or project-level into
 #   <host>/.agents/skills/coding-agent-work-loop/drivers/<name>.sh
 #
@@ -146,6 +147,7 @@ WORKTREE_GIT_USER_EMAIL=""
 #   claude    — Claude Code             （默认；行为完全等同未引入 driver 抽象前）
 #   opencode  — OpenCode (sst/opencode)
 #   codex     — Codex CLI (OpenAI)
+#   cursor    — Cursor Agent CLI（`agent`；headless 用 -p --trust --force）
 # 自定义：往 skill 的 scripts/drivers/<name>.sh 加，或放在项目级
 #   <host>/.agents/skills/coding-agent-work-loop/drivers/<name>.sh
 WORKER_AGENT="claude"
@@ -160,9 +162,10 @@ WORKER_AGENT="claude"
 # （只有 WORKER_AGENT=claude 时生效；其他 driver 读各自的 *_EXTRA_FLAGS。）
 CLAUDE_EXTRA_FLAGS="--dangerously-skip-permissions"
 
-# OpenCode / Codex 启动 flag（按需打开）：
+# OpenCode / Codex / Cursor 启动 flag（按需打开）：
 # OPENCODE_EXTRA_FLAGS=""
 # CODEX_EXTRA_FLAGS=""
+# CURSOR_AGENT_EXTRA_FLAGS=""
 
 # ── Env passed to worker / 传给 worker 的 env ──
 

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -11,17 +11,33 @@ The daemon / dispatch scripts and "which CLI runs in tmux" are separated by a **
 | `claude`   | `claude`   | `~/.claude/projects/<encoded-cwd>/*.jsonl` | `esc to interrupt` | ✅ default, stable |
 | `opencode` | `opencode` | `~/.local/share/opencode/...` (version-dependent) | `thinking` / `working` / `esc to interrupt` / `stop` | ⚠️ first-pass; verify against your installed version |
 | `codex`    | `codex`    | `~/.codex/sessions/` or `~/.codex/history/` | `thinking` / `running` / `esc to interrupt` | ⚠️ first-pass; verify against your installed version |
+| `cursor`   | `agent`    | _(not cwd-probed; always new session)_ | `thinking` / `running` / spinner / `esc to interrupt` | ✅ stable on macOS (headless `-p --trust --force`) |
 
-Switching:
+Switching (Cursor example):
 
 ```bash
-# 1. Install the CLI (codex shown here)
+# 1. Ensure Cursor Agent CLI is on PATH (`agent --help`)
+#    macOS: usually bundled with Cursor IDE
+
+# 2. In coding-agent.config:
+WORKER_AGENT="cursor"
+
+# 3. Re-run setup.sh so the daemon EnvironmentFile PATH includes `agent`
+WORKER_AGENT=cursor bash ~/.agents/skills/coding-agent-work-loop/setup.sh ~/path/to/your-project
+```
+
+> Under launchd/systemd, ensure `GH_TOKEN` is in the daemon EnvironmentFile so the worker's `gh` CLI uses the intended PAT (see `WORKER_PASS_ENV` in `coding-agent.config`).
+
+Switching (Codex example):
+
+```bash
+# 1. Install the CLI
 npm i -g @openai/codex
 
 # 2. In coding-agent.config:
 WORKER_AGENT="codex"
 
-# 3. Re-run setup.sh so the systemd EnvironmentFile PATH points to the new CLI
+# 3. Re-run setup.sh so the daemon EnvironmentFile PATH points to the new CLI
 WORKER_AGENT=codex bash ~/.agents/skills/coding-agent-work-loop/setup.sh ~/path/to/your-project
 ```
 

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -11,7 +11,7 @@ The daemon / dispatch scripts and "which CLI runs in tmux" are separated by a **
 | `claude`   | `claude`   | `~/.claude/projects/<encoded-cwd>/*.jsonl` | `esc to interrupt` | ✅ default, stable |
 | `opencode` | `opencode` | `~/.local/share/opencode/...` (version-dependent) | `thinking` / `working` / `esc to interrupt` / `stop` | ⚠️ first-pass; verify against your installed version |
 | `codex`    | `codex`    | `~/.codex/sessions/` or `~/.codex/history/` | `thinking` / `running` / `esc to interrupt` | ⚠️ first-pass; verify against your installed version |
-| `cursor`   | `agent`    | _(not cwd-probed; always new session)_ | `thinking` / `running` / spinner / `esc to interrupt` | ✅ stable on macOS (headless `-p --trust --force`) |
+| `cursor`   | `agent`    | _(not cwd-probed; always new session)_ | `thinking` / `running` / spinner / `esc to interrupt` | ✅ stable on macOS (headless `-p --trust --force`); no mid-session stdin inject — new comments respawn session |
 
 Switching (Cursor example):
 
@@ -27,6 +27,8 @@ WORKER_AGENT=cursor bash ~/.agents/skills/coding-agent-work-loop/setup.sh ~/path
 ```
 
 > Under launchd/systemd, ensure `GH_TOKEN` is in the daemon EnvironmentFile so the worker's `gh` CLI uses the intended PAT (see `WORKER_PASS_ENV` in `coding-agent.config`).
+
+> **Cursor caveat:** `-p` is non-interactive print mode — mid-task issue/PR comments cannot be injected via stdin. The driver kills the live session and respawns with the new prompt (Case B) instead of silently dropping it.
 
 Switching (Codex example):
 

--- a/docs/drivers.zh.md
+++ b/docs/drivers.zh.md
@@ -11,17 +11,33 @@
 | `claude`   | `claude`   | `~/.claude/projects/<encoded-cwd>/*.jsonl` | `esc to interrupt` | ✅ 默认、稳定 |
 | `opencode` | `opencode` | `~/.local/share/opencode/...` (按版本) | `thinking` / `working` / `esc to interrupt` / `stop` | ⚠️ 首版适配，请按你装的版本核对 |
 | `codex`    | `codex`    | `~/.codex/sessions/` 或 `~/.codex/history/` | `thinking` / `running` / `esc to interrupt` | ⚠️ 首版适配，请按你装的版本核对 |
+| `cursor`   | `agent`    | _(不按 cwd 探测；始终 new session)_ | `thinking` / `running` / spinner / `esc to interrupt` | ✅ macOS 验收通过（headless `-p --trust --force`） |
 
-切换：
+切换（Cursor 示例）：
 
 ```bash
-# 1. 装好对应 CLI（这里以 codex 为例）
-npm i -g @openai/codex   # 或对应安装命令
+# 1. 确保 Cursor Agent CLI 在 PATH 上（`agent --help`）
+#    macOS：通常随 Cursor IDE 安装
+
+# 2. 在 coding-agent.config 里改
+WORKER_AGENT="cursor"
+
+# 3. 重跑 setup.sh 让 daemon EnvironmentFile 的 PATH 包含 `agent`
+WORKER_AGENT=cursor bash ~/.agents/skills/coding-agent-work-loop/setup.sh ~/path/to/your-project
+```
+
+> launchd/systemd 下请确保 EnvironmentFile 含 `GH_TOKEN`，worker 里的 `gh` 才会用预期 PAT（见 `coding-agent.config` 的 `WORKER_PASS_ENV`）。
+
+切换（Codex 示例）：
+
+```bash
+# 1. 装好对应 CLI
+npm i -g @openai/codex
 
 # 2. 在 coding-agent.config 里改
 WORKER_AGENT="codex"
 
-# 3. 重跑 setup.sh 让 systemd EnvironmentFile 的 PATH 指向新 CLI
+# 3. 重跑 setup.sh 让 daemon EnvironmentFile 的 PATH 指向新 CLI
 WORKER_AGENT=codex bash ~/.agents/skills/coding-agent-work-loop/setup.sh ~/path/to/your-project
 ```
 

--- a/docs/drivers.zh.md
+++ b/docs/drivers.zh.md
@@ -11,7 +11,7 @@
 | `claude`   | `claude`   | `~/.claude/projects/<encoded-cwd>/*.jsonl` | `esc to interrupt` | ✅ 默认、稳定 |
 | `opencode` | `opencode` | `~/.local/share/opencode/...` (按版本) | `thinking` / `working` / `esc to interrupt` / `stop` | ⚠️ 首版适配，请按你装的版本核对 |
 | `codex`    | `codex`    | `~/.codex/sessions/` 或 `~/.codex/history/` | `thinking` / `running` / `esc to interrupt` | ⚠️ 首版适配，请按你装的版本核对 |
-| `cursor`   | `agent`    | _(不按 cwd 探测；始终 new session)_ | `thinking` / `running` / spinner / `esc to interrupt` | ✅ macOS 验收通过（headless `-p --trust --force`） |
+| `cursor`   | `agent`    | _(不按 cwd 探测；始终 new session)_ | `thinking` / `running` / spinner / `esc to interrupt` | ✅ macOS 验收通过（headless `-p --trust --force`）；不支持 mid-session stdin 注入，新 comment 会重起 session |
 
 切换（Cursor 示例）：
 
@@ -27,6 +27,8 @@ WORKER_AGENT=cursor bash ~/.agents/skills/coding-agent-work-loop/setup.sh ~/path
 ```
 
 > launchd/systemd 下请确保 EnvironmentFile 含 `GH_TOKEN`，worker 里的 `gh` 才会用预期 PAT（见 `coding-agent.config` 的 `WORKER_PASS_ENV`）。
+
+> **Cursor 注意：** `-p` 是 non-interactive print 模式，mid-task 的 issue/PR comment 无法通过 stdin 注入。driver 会 kill 当前 session 并用新 prompt 重起（Case B），不会 silent drop。
 
 切换（Codex 示例）：
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -241,7 +241,7 @@ Polling has up to 1 minute of latency. For instant:
 
 ## Custom worker (not Claude Code)
 
-Worker selection now goes through a thin **driver layer** — no fork needed. Set `WORKER_AGENT=<name>` in `coding-agent.config`. Built-ins: `claude` (default), `opencode`, `codex`. To add your own agent, drop a `scripts/drivers/<name>.sh` (or project-level override at `<host>/.agents/skills/coding-agent-work-loop/drivers/<name>.sh`) — see [drivers.md](drivers.md) for the 5-function contract and a template.
+Worker selection now goes through a thin **driver layer** — no fork needed. Set `WORKER_AGENT=<name>` in `coding-agent.config`. Built-ins: `claude` (default), `opencode`, `codex`, `cursor`. To add your own agent, drop a `scripts/drivers/<name>.sh` (or project-level override at `<host>/.agents/skills/coding-agent-work-loop/drivers/<name>.sh`) — see [drivers.md](drivers.md) for the 5-function contract and a template.
 
 ## Troubleshooting
 

--- a/docs/operations.zh.md
+++ b/docs/operations.zh.md
@@ -241,7 +241,7 @@ bash ~/.agents/skills/coding-agent-work-loop/setup.sh <host>
 
 ## 自定义 worker（不是 Claude Code）
 
-Worker 切换走一层薄的 **driver 抽象**，不需要 fork。在 `coding-agent.config` 里设 `WORKER_AGENT=<name>` 即可。内置：`claude`（默认）、`opencode`、`codex`。想加自家 agent，往 `scripts/drivers/<name>.sh` 加（或放项目级 `<host>/.agents/skills/coding-agent-work-loop/drivers/<name>.sh`） — 5 个函数的接口契约和模板见 [drivers.zh.md](drivers.zh.md)。
+Worker 切换走一层薄的 **driver 抽象**，不需要 fork。在 `coding-agent.config` 里设 `WORKER_AGENT=<name>` 即可。内置：`claude`（默认）、`opencode`、`codex`、`cursor`。想加自家 agent，往 `scripts/drivers/<name>.sh` 加（或放项目级 `<host>/.agents/skills/coding-agent-work-loop/drivers/<name>.sh`） — 5 个函数的接口契约和模板见 [drivers.zh.md](drivers.zh.md)。
 
 ## 故障排查
 

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -54,7 +54,7 @@ LABEL_DONE="${LABEL_DONE:-Done}"
 # ISO 639-1 code. Default "en"。代码 / commit / 分支名仍按仓库惯例，不受影响。
 OUTPUT_LANGUAGE="${OUTPUT_LANGUAGE:-en}"
 
-# Worker agent CLI（claude / opencode / codex / 你自家 driver）。
+# Worker agent CLI（claude / opencode / codex / cursor / 你自家 driver）。
 # 默认 claude → 行为完全等同未引入 driver 抽象前。
 WORKER_AGENT="${WORKER_AGENT:-claude}"
 

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -33,7 +33,7 @@ fi
 
 # 2. worktree
 if [ -d "$WORKTREE_DIR" ]; then
-    log "  worktree 目录已存在：$WORKTREE_DIR（跳过创建）"
+    log "  worktree 目录已存在：${WORKTREE_DIR}（跳过创建）"
 else
     mkdir -p "$WORKTREE_BASE"
     git worktree add "$WORKTREE_DIR" "$BRANCH"

--- a/scripts/dispatch-issue-comment.sh
+++ b/scripts/dispatch-issue-comment.sh
@@ -54,9 +54,11 @@ flip_label() {
 # Case A: session 还活着 → 注入 prompt
 if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
     log "issue #$ISSUE -> 注入现有 session $TMUX_SESSION (agent=$WORKER_AGENT)"
-    agent_inject_prompt "$TMUX_SESSION" "$PROMPT_FILE"
-    flip_label
-    exit 0
+    if agent_inject_prompt "$TMUX_SESSION" "$PROMPT_FILE"; then
+        flip_label
+        exit 0
+    fi
+    log "issue #$ISSUE -> 注入失败，fallback 重起 session (agent=$WORKER_AGENT)"
 fi
 
 # Case B: worktree 还在，session 死了 → 重起 session（有历史就 resume）

--- a/scripts/dispatch-issue-comment.sh
+++ b/scripts/dispatch-issue-comment.sh
@@ -68,7 +68,10 @@ if [ -d "$WORKTREE" ]; then
         log "issue #$ISSUE -> 从 worktree 起全新 $WORKER_AGENT session $TMUX_SESSION（cwd 无历史）"
         CMD="$(agent_command_new "$WORKTREE" "$WORKER_SESSION" "$PROMPT_FILE")"
     fi
-    mapfile -d '' -t tmux_env < <(tmux_env_args)
+    tmux_env=()
+    while IFS= read -r -d '' _tmux_e; do
+        tmux_env+=("$_tmux_e")
+    done < <(tmux_env_args)
     tmux new-session -d -s "$TMUX_SESSION" "${tmux_env[@]}" -c "$WORKTREE" "$CMD"
     start_session_logging "$TMUX_SESSION" 2>/dev/null || true
     flip_label

--- a/scripts/dispatch-new-issue.sh
+++ b/scripts/dispatch-new-issue.sh
@@ -53,7 +53,10 @@ fi
 #    新 issue 一律走 agent_command_new（worktree 刚建，无历史）。
 log "spawn $TMUX_SESSION in $WORKTREE (agent=$WORKER_AGENT)"
 CMD="$(agent_command_new "$WORKTREE" "$WORKER_SESSION" "$PROMPT_FILE")"
-mapfile -d '' -t tmux_env < <(tmux_env_args)
+tmux_env=()
+while IFS= read -r -d '' _tmux_e; do
+    tmux_env+=("$_tmux_e")
+done < <(tmux_env_args)
 tmux new-session -d -s "$TMUX_SESSION" "${tmux_env[@]}" -c "$WORKTREE" "$CMD"
 
 # 4.5 pane 输出旁路到日志文件，session 退出后仍可回看

--- a/scripts/dispatch-pr-comment.sh
+++ b/scripts/dispatch-pr-comment.sh
@@ -68,9 +68,11 @@ flip_label() {
 if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
     log "PR #$PR -> 注入 $TMUX_SESSION (agent=$WORKER_AGENT)"
     start_session_logging "$TMUX_SESSION"
-    agent_inject_prompt "$TMUX_SESSION" "$PROMPT_FILE"
-    flip_label
-    exit 0
+    if agent_inject_prompt "$TMUX_SESSION" "$PROMPT_FILE"; then
+        flip_label
+        exit 0
+    fi
+    log "PR #$PR -> 注入失败，fallback 重起 session (agent=$WORKER_AGENT)"
 fi
 
 # Case B: worktree 还在，session 没了 → 重起（有历史就 resume）

--- a/scripts/dispatch-pr-comment.sh
+++ b/scripts/dispatch-pr-comment.sh
@@ -82,7 +82,10 @@ if [ -d "$WORKTREE" ]; then
         log "PR #$PR -> 从 worktree 起全新 $WORKER_AGENT session $TMUX_SESSION（cwd 无历史）"
         CMD="$(agent_command_new "$WORKTREE" "$WORKER_SESSION" "$PROMPT_FILE")"
     fi
-    mapfile -d '' -t tmux_env < <(tmux_env_args)
+    tmux_env=()
+    while IFS= read -r -d '' _tmux_e; do
+        tmux_env+=("$_tmux_e")
+    done < <(tmux_env_args)
     tmux new-session -d -s "$TMUX_SESSION" "${tmux_env[@]}" -c "$WORKTREE" "$CMD"
     start_session_logging "$TMUX_SESSION"
     flip_label
@@ -118,7 +121,10 @@ if agent_has_history "$WORKTREE"; then
 else
     CMD="$(agent_command_new "$WORKTREE" "$WORKER_SESSION" "$PROMPT_FILE")"
 fi
-mapfile -d '' -t tmux_env < <(tmux_env_args)
+tmux_env=()
+while IFS= read -r -d '' _tmux_e; do
+    tmux_env+=("$_tmux_e")
+done < <(tmux_env_args)
 tmux new-session -d -s "$TMUX_SESSION" "${tmux_env[@]}" -c "$WORKTREE" "$CMD"
 start_session_logging "$TMUX_SESSION"
 

--- a/scripts/drivers/cursor.sh
+++ b/scripts/drivers/cursor.sh
@@ -5,7 +5,9 @@
 # 历史存放：Cursor 对话不在 cwd-hash 路径下，本 driver 无法廉价探测 → 一律走 new。
 # Busy 探测：tmux pane 里出现 thinking / running / spinner / esc to interrupt 等。
 # 新起：agent -p --trust --force --output-format text [extra-flags] "<prompt>"
-# 续接：agent --continue -p --trust --force --output-format text [extra-flags] "<prompt>"
+# 续接：fallback 到 new（`agent --continue -p` 未实测，TODO）
+# 注入：-p 是 non-interactive print 模式，不支持 mid-session stdin 注入 →
+#       agent_inject_prompt 杀 session 并 return 1，让 dispatch 走 Case B 重起。
 #
 # 配置开关：CURSOR_AGENT_EXTRA_FLAGS（按需追加 flag；默认已含 -p --trust --force）
 
@@ -20,7 +22,15 @@ agent_is_busy() {
     local sess="$1"
     tmux has-session -t "$sess" 2>/dev/null || return 1
     tmux capture-pane -t "$sess" -p 2>/dev/null | \
-        grep -qiE 'thinking|running|tool|generating|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|esc to interrupt'
+        grep -qiE 'thinking|running|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|esc to interrupt'
+}
+
+agent_inject_prompt() {
+    local sess="$1"
+    # -p 从 argv 读 prompt、不读 stdin；paste-buffer 注入会被吞掉。
+    # 杀 session 让 dispatch-*-comment.sh Case A 失败后 fallback 到 Case B 重起。
+    tmux kill-session -t "$sess" 2>/dev/null || true
+    return 1
 }
 
 agent_command_new() {
@@ -33,10 +43,7 @@ agent_command_new() {
 }
 
 agent_command_resume() {
-    local cwd="$1"
-    local name="$2"
-    local prompt_file="$3"
-    printf 'agent --continue -p --trust --force --output-format text %s "$(cat %s)"' \
-        "${CURSOR_AGENT_EXTRA_FLAGS:-}" \
-        "$prompt_file"
+    # Cursor -p 是 non-interactive 一次性 print；`agent --continue -p` 未实测，
+    # 先 fallback 到 new，避免项目级 override agent_has_history 时踩 surprise。
+    agent_command_new "$@"
 }

--- a/scripts/drivers/cursor.sh
+++ b/scripts/drivers/cursor.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Cursor Agent CLI (`agent`) driver。
+#
+# 文档：`agent --help`（Cursor IDE 自带 CLI，headless 用 -p / --print）
+# 历史存放：Cursor 对话不在 cwd-hash 路径下，本 driver 无法廉价探测 → 一律走 new。
+# Busy 探测：tmux pane 里出现 thinking / running / spinner / esc to interrupt 等。
+# 新起：agent -p --trust --force --output-format text [extra-flags] "<prompt>"
+# 续接：agent --continue -p --trust --force --output-format text [extra-flags] "<prompt>"
+#
+# 配置开关：CURSOR_AGENT_EXTRA_FLAGS（按需追加 flag；默认已含 -p --trust --force）
+
+agent_bin() { echo "agent"; }
+
+agent_has_history() {
+    # Cursor 不在 worktree cwd 下留可探测的历史路径；dispatch 始终用 agent_command_new。
+    return 1
+}
+
+agent_is_busy() {
+    local sess="$1"
+    tmux has-session -t "$sess" 2>/dev/null || return 1
+    tmux capture-pane -t "$sess" -p 2>/dev/null | \
+        grep -qiE 'thinking|running|tool|generating|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|esc to interrupt'
+}
+
+agent_command_new() {
+    local cwd="$1"
+    local name="$2"
+    local prompt_file="$3"
+    printf 'agent -p --trust --force --output-format text %s "$(cat %s)"' \
+        "${CURSOR_AGENT_EXTRA_FLAGS:-}" \
+        "$prompt_file"
+}
+
+agent_command_resume() {
+    local cwd="$1"
+    local name="$2"
+    local prompt_file="$3"
+    printf 'agent --continue -p --trust --force --output-format text %s "$(cat %s)"' \
+        "${CURSOR_AGENT_EXTRA_FLAGS:-}" \
+        "$prompt_file"
+}

--- a/setup.sh
+++ b/setup.sh
@@ -82,7 +82,7 @@ WORKER_AGENT_PICK="${WORKER_AGENT:-claude}"
 # shellcheck source=scripts/drivers/_common.sh
 source "$SKILL_DIR/scripts/drivers/_common.sh"
 PROJECT_ROOT="$HOST" source_driver "$WORKER_AGENT_PICK" || {
-    echo "❌ 找不到 driver '$WORKER_AGENT_PICK'。内置：claude / opencode / codex。"
+    echo "❌ 找不到 driver '$WORKER_AGENT_PICK'。内置：claude / opencode / codex / cursor。"
     exit 1
 }
 WORKER_BIN="$(agent_bin)"


### PR DESCRIPTION
## Summary

- 新增内置 `scripts/drivers/cursor.sh`，支持 `WORKER_AGENT=cursor` 直接使用 Cursor Agent CLI（`agent -p --trust --force --output-format text`）作为 worker，无需项目级 driver override。
- 更新 README / SKILL / drivers / operations 文档及 `coding-agent.config.example`（含 `CURSOR_AGENT_EXTRA_FLAGS`）。
- 附带 macOS bash 3.2 兼容修复：`create-worktree.sh` 中 `$WORKTREE_DIR（` → `${WORKTREE_DIR}（`；dispatch 脚本用 `while read` 替代 `mapfile`（验收环境实测通过）。

## 背景

本地验收（macOS + launchd + Cursor）已在 [luohui8891/coding-agent-acceptance-test](https://github.com/luohui8891/coding-agent-acceptance-test) 完成端到端派工（issue #1 手动 dispatch、issue #2 launchd 自动 dispatch），此前依赖项目级 `.agents/skills/.../drivers/cursor.sh` override。本 PR 将该 driver 上游化。

## Test plan

- [x] `WORKER_AGENT=cursor bash -c 'source scripts/drivers/_common.sh && source_driver cursor && agent_bin'` 输出 `agent`
- [x] macOS 上 `dispatch-new-issue.sh` 不再因 `mapfile` 或 `$WORKTREE_DIR（` 崩溃
- [x] `coding-agent.config` 设 `WORKER_AGENT=cursor` 后重跑 `setup.sh`，daemon 能 spawn tmux worker
- [x] issue 打 `pending/agent` 后 worker 评论并翻 label 到 `pending/human`
- [x] launchd 下确认 EnvironmentFile 含 `GH_TOKEN`（`WORKER_PASS_ENV`）

### 验证记录（2026-05-22）

| 项 | 证据 |
|----|------|
| driver 加载 | `agent_bin` → `agent`；`command -v agent` → `~/.local/bin/agent` |
| bash 3.2 兼容 | scripts 无 `mapfile`；`${WORKTREE_DIR}（` 在 bash 3.2 + `set -u` 下通过；poll.log 有 `worktree 目录已存在：...（跳过创建）` 无 crash |
| setup + spawn | launchd job `dev.luosky.coding-agent-work-loop.coding-agent-acceptance-test` 运行中；poll.log：`spawn ... (agent=cursor)` |
| 端到端 | issue [#1](https://github.com/luohui8891/coding-agent-acceptance-test/issues/1) / [#2](https://github.com/luohui8891/coding-agent-acceptance-test/issues/2) → label `pending/human`，评论 `ACCEPTANCE OK from Cursor agent worker` |
| GH_TOKEN | `~/.config/coding-agent-work-loop/coding-agent-acceptance-test.conf` 含 `GH_TOKEN`；`coding-agent.config` 中 `WORKER_PASS_ENV` 含 `GH_TOKEN` |